### PR TITLE
Add support for creating custom blockchain networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `besu_systemd_state` | restarted | The default option for the systemd service state |
 | `besu_host_ip` | "" | The host IP that Besu uses for the P2P network. This specifies the host on which P2P listens |
 | `besu_default_ip` | "{{ default(ansible_host) \| default('127.0.0.1') }}" | The fallback default for `besu_host_ip` |
-| `besu_network` | mainnet | The network that this node will join. Other values are 'ropsten', 'rinkeby', 'goerli', 'dev'|
+| `besu_network` | mainnet | The network that this node will join. Other values are 'ropsten', 'rinkeby', 'goerli', 'dev' and 'custom' |
+| `besu_genesis_path | ___unset___ | The path to the genesis file, only valid when `besu_network` is `custom` |
 | `besu_sync_mode` | FAST | Specifies the synchronization mode. Other values are 'FULL' |
 | `besu_log_level` | INFO | The log level to use. Other log levels are 'OFF', 'FATAL', 'WARN', 'INFO', 'DEBUG', 'TRACE', 'ALL' |
 | `besu_p2p_port` | 30303 | Specifies the P2P listening ports (UDP and TCP). Ports must be exposed appropriately |

--- a/templates/config.toml.j2
+++ b/templates/config.toml.j2
@@ -2,7 +2,11 @@
 data-path="{{besu_data_dir}}"
 logging="{{besu_log_level}}"
 
+{% if besu_network.lower() != "custom" %}
 network="{{besu_network}}"
+{% else %}
+genesis-file="{{ besu_genisis_path }}
+{% endif %}
 sync-mode="{{besu_sync_mode}}"
 host-whitelist=[{{besu_host_whitelist|map('to_json')|join(',')}}]
 


### PR DESCRIPTION
Allow the use of a custom genesis file.
We do not help you getting it to the system though.