### PR TITLE
Decouple miner vanity string from enabling mining

### DIFF
--- a/templates/config.toml.j2
+++ b/templates/config.toml.j2
@@ -25,9 +25,10 @@ identity="{{ besu_identity }}"
 # miner
 miner-enabled=true
 miner-coinbase="{{besu_miner_coinbase}}"
+{% endif %}
+
 {% if besu_miner_extra_data != "" %}
 miner-extra-data="{{besu_miner_extra_data}}"
-{% endif %}
 {% endif %}
 
 {% if besu_rpc_http_enabled|bool == True %}


### PR DESCRIPTION
Right now the miner vanity string is tied to miner enabled.  For clique
and IBFT mining is auto-enabled when the nodeID matches the validators
so we need to be able to set vanity at any time.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>