### PR TITLE
Support new named networks correctly

### DIFF
--- a/templates/config.toml.j2
+++ b/templates/config.toml.j2
@@ -16,11 +16,12 @@ required-blocks=[{{besu_required_blocks|map('to_json')|join(',')}}]
 target-gas-limit="{{ besu_target_gas_limit }}"
 {% endif %}
 
-{% if besu_network.lower() in ["mainnet", "rinkeby", "goerli", "ropsten", "classic", "mordor", "kotti", "dev"] %}
-network="{{besu_network}}"
-{% else %}
+{% if besu_genesis_path is defined and besu_genesis_path != "" %}
 genesis-file="{{ besu_genesis_path }}"
+{% else %}
+network="{{besu_network}}"
 {% endif %}
+
 min-gas-price={{ besu_min_gas }}
 sync-mode="{{besu_sync_mode}}"
 host-whitelist=[{{besu_host_whitelist|map('to_json')|join(',')}}]


### PR DESCRIPTION
Currently if the besu_network isn't one of the hard coded options, the value is ignored and a path to a custom genesis file is used. For the kiln network this results in the role failing because kiln is a built-in network and so besu_genesis_path is undefined.  

This switches the logic to use the specified network, regardless of its value unless besu_genesis_path is specified so that new named networks are automatically supported but users can still specify their own genesis file.