### PR TITLE
Allow data-storage-format, engine-jwt-disabled, engine-jwt-secret and engine-rpc-port to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `besu_required_blocks` | [] | Requires a peer with the specified block number to have the specified hash when connecting, or Besu rejects that peer |
 | `besu_sync_mode` | FAST | Specifies the synchronization mode. Other values are 'FULL' |
 | `besu_log_level` | INFO | The log level to use. Other log levels are 'OFF', 'FATAL', 'WARN', 'INFO', 'DEBUG', 'TRACE', 'ALL' |
+| `besu_data_storage_format` | ___unset___ | Data storage format. Possible values are 'FOREST' and 'BONSAI'. The besu default is 'FOREST' |
+| `besu_engine_jwt_disabled` | ___unset___ | Disables authentication for the Engine API. The besu default is false. |
+| `besu_engine_jwt_secret` | ___unset___ | Shared secret used to authenticate consensus clients when using the Engine JSON-RPC API (both HTTP and WebSocket). Contents of file must be at least 32 hex-encoded bytes and not begin with 0x. |
+| `besu_engine_rpc_port` | ___unset___ | The listening port for the Engine API calls (ENGINE, ETH) for JSON-RPC over HTTP and WebSocket. The besu default is 8551 |
 | `besu_p2p_port` | 30303 | Specifies the P2P listening ports (UDP and TCP). Ports must be exposed appropriately |
 | `besu_min_gas` | 1000 | The minimum price that a transaction offers for it to be included in a mined block |
 | `besu_miner_enabled` | false | Enables mining when the node is started |

--- a/templates/config.toml.j2
+++ b/templates/config.toml.j2
@@ -1,6 +1,19 @@
 # data
 data-path="{{besu_data_dir}}"
 logging="{{besu_log_level}}"
+{% if besu_data_storage_format is defined and besu_data_storage_format != "" %}
+data-storage-format="{{besu_data_storage_format}}"
+{% endif %}
+
+{% if besu_engine_jwt_disabled is defined and besu_engine_jwt_disabled|bool == True %}
+engine-jwt-disabled=true
+{% endif %}
+{% if besu_engine_jwt_secret is defined and besu_engine_jwt_secret != "" %}
+engine-jwt-secret="{{besu_engine_jwt_secret}}"
+{% endif %}
+{% if besu_engine_rpc_port is defined and besu_engine_rpc_port != "" %}
+engine-rpc-port={{besu_engine_rpc_port}}
+{% endif %}
 
 {% if besu_node_private_key_file != "" %}
 # private_key


### PR DESCRIPTION
This will prevent the internal bonsai canary node from defaulting back to forest mode.

It will also allow besu+teku combinations to be configured without having to use `besu_cmdline_args`.