### PR TITLE
Do not set logging=INFO by default to allow custom Log4j configuration to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `besu_node_private_key_file` | "" | Path for node private key, if supplied. This needs to include the node key file name and path like so `/home/me/me_node/myPrivateKey`. If not supplied Besu will create one automatically |
 | `besu_data_dir` | /opt/besu/data | Path for data directory|
 | `besu_log_dir` | /var/log/besu | Path for logs |
-| `besu_log4j_config_file` | "" | Absolute path for a custom log4j config file |
+| `besu_log4j_config_file` |  ___unset___ | Absolute path for a custom log4j config file. Note this log configuration is overriden if `besu_log_level` is set |
 | `besu_profile_file` | /etc/profile.d/besu-path.sh | Path to allow loading Besu into the system PATH |
 | `besu_managed_service` | true | Enables a systemd service (or launchd if on Darwin) |
 | `besu_launchd_dir` | /Library/LaunchAgents | The default launchd directory  |
@@ -56,7 +56,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `besu_genesis_path` | ___unset___ | The path to the genesis file, only valid when `besu_network` is `custom` |
 | `besu_required_blocks` | [] | Requires a peer with the specified block number to have the specified hash when connecting, or Besu rejects that peer |
 | `besu_sync_mode` | FAST | Specifies the synchronization mode. Other values are 'FULL' |
-| `besu_log_level` | INFO | The log level to use. Other log levels are 'OFF', 'FATAL', 'WARN', 'INFO', 'DEBUG', 'TRACE', 'ALL' |
+| `besu_log_level` | ___unset___ | The log level to use. Other log levels are 'OFF', 'FATAL', 'WARN', 'INFO', 'DEBUG', 'TRACE', 'ALL'. Note setting this has priority over the configuration set by `besu_log4j_config_file` |
 | `besu_data_storage_format` | ___unset___ | Data storage format. Possible values are 'FOREST' and 'BONSAI'. The besu default is 'FOREST' |
 | `besu_engine_jwt_disabled` | ___unset___ | Disables authentication for the Engine API. The besu default is false. |
 | `besu_engine_jwt_secret` | ___unset___ | Path to the shared secret file used to authenticate consensus clients when using the Engine JSON-RPC API (both HTTP and WebSocket). Contents of file could be set with `besu_engine_jwt_secret_content` and must be at least 32 hex-encoded bytes, not begin with 0x, otherwise a random value if automatically set, but only if a secret does not already exist on disk. If not specified, by default Besu creates an ephemeral secret in the data dir, that is deleted on exit. |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,7 +21,6 @@ besu_config_dir: "/etc/besu"
 besu_config_template: "config.toml.j2"
 besu_data_dir: "{{ besu_base_dir }}/data"
 besu_log_dir: "/var/log/besu"
-besu_log4j_config_file: ""
 besu_profile_file: "/etc/profile.d/besu-path.sh"
 
 # Managed service config
@@ -37,7 +36,6 @@ besu_host_ip: ""
 besu_default_ip: "127.0.0.1"
 besu_network: mainnet
 besu_sync_mode: FAST
-besu_log_level: INFO
 besu_p2p_port: 30303
 besu_min_gas: 1000
 besu_miner_extra_data: ""

--- a/templates/besu.service.j2
+++ b/templates/besu.service.j2
@@ -6,7 +6,7 @@ After=syslog.target network.target
 User={{ besu_user }}
 Group={{ besu_group }}
 Environment=HOME=/home/{{ besu_user }}
-{% if besu_log4j_config_file != "" %}
+{% if besu_log4j_config_file is defined %}
 Environment=LOG4J_CONFIGURATION_FILE={{ besu_log4j_config_file }}
 {% endif %}
 {% if besu_env_opts %}

--- a/templates/config.toml.j2
+++ b/templates/config.toml.j2
@@ -1,6 +1,8 @@
 # data
 data-path="{{besu_data_dir}}"
+{% if besu_log_level is defined %}
 logging="{{besu_log_level}}"
+{% endif %}
 {% if besu_data_storage_format is defined and besu_data_storage_format != "" %}
 data-storage-format="{{besu_data_storage_format}}"
 {% endif %}


### PR DESCRIPTION
By default this role sets the configuration option `logging` to `INFO`, and this has the effect to always override the potential custom log configuration file provided when starting Besu.

This PR does not set the `logging` option by default, so the custom log configuration can work if set.

Signed-off-by: Fabio Di Fabio <fabio.difabio@consensys.net>