### PR TITLE
select download url based on besu_version

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -42,6 +42,12 @@
     dest: "/etc/logrotate.d/besu"
   become: true
 
+# besu binary files are hosted in github for any version after 24.1.2
+- name: Update besu_download_url to provide support for older versions
+  set_fact:
+    besu_download_url: "https://hyperledger.jfrog.io/artifactory/besu-binaries/besu/{{ besu_version }}/besu-{{ besu_version }}.tar.gz"
+  when: "{{ besu_version is version('24.1.2', operator='le', strict=True, version_type='semver') }}" | bool
+
 - name: Extract Besu source to install directory
   unarchive:
     src: "{{ '/tmp/besu/build/distributions/besu-' + besu_version + '.tar.gz' if besu_build_from_source else besu_download_url }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,13 +5,7 @@
       fail:
         msg: You must set "besu_version" for this role to run when not building Besu from source
       when: besu_version is not defined and not besu_build_from_source
-    - name: Check besu_version is not set when besu_build_from_source is set
-      fail:
-        msg: >-
-          The vars "besu_version" and "besu_build_from_source" are
-          incompatible. If trying to build a specific git refspec, use
-          "besu_git_refspec" instead of besu_version.
-      when: besu_version is defined and besu_build_from_source
+
     - name: Check besu_privacy_enabled is not set when fast sync is enabled
       fail:
         msg: Orion and Fast-Sync are incompatible


### PR DESCRIPTION
Last release prevents any older versions from working coz they haven't been moved to gh. This fixes that