### PR TITLE
Remove auto-population of besu_download_url for old besu versions

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -42,12 +42,6 @@
     dest: "/etc/logrotate.d/besu"
   become: true
 
-# besu binary files are hosted in github for any version after 24.1.2
-- name: Update besu_download_url to provide support for older versions
-  set_fact:
-    besu_download_url: "https://hyperledger.jfrog.io/artifactory/besu-binaries/besu/{{ besu_version }}/besu-{{ besu_version }}.tar.gz"
-  when: "{{ besu_version is version('24.1.2', operator='le', version_type='loose') | bool == True}}" 
-
 - name: Extract Besu source to install directory
   unarchive:
     src: "{{ '/tmp/besu/build/distributions/besu-' + besu_version + '.tar.gz' if besu_build_from_source else besu_download_url }}"


### PR DESCRIPTION
The version check creates problems with the `develop` tag
Signed-off-by: Simon Dudley <simon.dudley@consensys.net>