### PR TITLE
Speed up git clone by skipping recursive and history

### DIFF
--- a/tasks/compile.yml
+++ b/tasks/compile.yml
@@ -21,6 +21,8 @@
     repo: "{{ besu_git_repo }}"
     dest: '/tmp/besu'
     version: "{{ besu_git_commit }}"
+    recursive: false
+    depth: 1
 
 - name: Build Besu
   shell: "JAVA_HOME=$(update-java-alternatives --list | grep 17 | tail -n 1 | awk '{print $3}') ./gradlew --no-daemon --parallel clean assemble"


### PR DESCRIPTION
This clone command is used for `./gradlew assemble` which doesn't require the recursive reference tests.
Shallow clone is OK because we are building the target commit and disposing of the working copy

Bring clone down from ~94 seconds to ~4 seconds...

Before
```
TASK [consensys.hyperledger_besu : Clone Besu Sources] *************************
2024-04-19T05:28:16.375363 (delta: 0.0226)         elapsed: 141.895652 ******** 
changed: [10.0.0.63]

TASK [consensys.hyperledger_besu : Build Besu] *********************************
2024-04-19T05:29:50.765789 (delta: 94.390397)         elapsed: 236.286078 ***** 
changed: [10.0.0.63]
```

After
```
TASK [consensys.hyperledger_besu : Clone Besu Sources] *************************
2024-04-19T07:18:42.264370 (delta: 0.021689)         elapsed: 130.04367 ******* 
changed: [10.0.128.75]

TASK [consensys.hyperledger_besu : Build Besu] *********************************
2024-04-19T07:18:46.543386 (delta: 4.278995)         elapsed: 134.322686 ******
```

