### PR TITLE
Support for Besu latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
 | `besu_build_from_source` | ___unset___ |  When set to `true`, Besu is build from git sources. See also `besu_git_repo` and `besu_git_commit` |
-| `besu_version` | ___unset___ |  __REQUIRED__ if `besu_build_from_source` is false. Version of Besu to install and run. All available versions are listed on our Besu [solutions](https://github.com/hyperledger/besu/releases) page |
+| `besu_version` | ___unset___ |  __REQUIRED__ if `besu_build_from_source` is false. Version of Besu to install and run. All available versions are listed on our Besu [solutions](https://github.com/hyperledger/besu/releases) page. Can use `latest` to install the latest released version |
 | `besu_git_repo` | https://github.com/hyperledger/besu.git | The URL to use when cloning besu sources. Only necessary when `besu_build_from_source` is `true`. |
 | `besu_git_commit` | master | The git commit to use when building Besu from source. Can be a branchname, commit hash, or anything that's legal to be used as an argument to `git checkout`. Only used if `besu_build_from_source` is `true`. |
 | `besu_user` | besu | Besu user |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,8 @@ besu_user: besu
 besu_group: "{{ besu_user }}"
 
 # Version to install
-besu_download_url: "https://github.com/hyperledger/besu/releases/download/{{ besu_version }}/besu-{{ besu_version }}.tar.gz"
+besu_download_url: "https://github.com/hyperledger/besu/releases/download/{{ _besu_version }}/besu-{{ _besu_version }}.tar.gz"
+besu_latest_version_url: "https://api.github.com/repos/hyperledger/besu/releases/latest"
 
 # Building from source
 besu_build_from_source: false
@@ -14,7 +15,7 @@ besu_git_commit: "master"
 
 # Directory paths
 besu_base_dir: "/opt/besu"
-besu_install_dir: "{{ besu_base_dir }}/besu-{{ besu_version }}"
+besu_install_dir: "{{ besu_base_dir }}/besu-{{ _besu_version }}"
 besu_current_dir: "{{ besu_base_dir }}/current"
 besu_node_private_key_file: ""
 besu_config_dir: "/etc/besu"

--- a/tasks/compile.yml
+++ b/tasks/compile.yml
@@ -39,4 +39,4 @@
 
 - name: Set Besu Version Fact
   set_fact:
-    besu_version: "{{ besu_version_cmd.stdout }}"
+    _besu_version: "{{ besu_version_cmd.stdout }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -44,7 +44,7 @@
 
 - name: Extract Besu source to install directory
   unarchive:
-    src: "{{ '/tmp/besu/build/distributions/besu-' + besu_version + '.tar.gz' if besu_build_from_source else besu_download_url }}"
+    src: "{{ '/tmp/besu/build/distributions/besu-' + _besu_version + '.tar.gz' if besu_build_from_source else besu_download_url }}"
     remote_src: yes
     dest: "{{ besu_install_dir }}"
     owner: "{{ besu_user }}"

--- a/tasks/latest.yml
+++ b/tasks/latest.yml
@@ -1,0 +1,19 @@
+- name: Get the version response
+  ansible.builtin.uri:
+    url: "{{ besu_latest_version_url }}"
+    method: GET
+    status_code: 200
+  register: _besu_latest_response
+
+- name: Extract the Besu version
+  ansible.builtin.set_fact:
+    _besu_version: "{{ _besu_latest_response.json.tag_name }}"
+
+- name: Validate the Besu version
+  ansible.builtin.assert:
+    that: _besu_version is search("^[0-9]+\.[0-9]+\.[0-9]+(-RC[0-9])?$")
+    fail_msg: "Retrieved version [{{ _besu_version }}] is  not a valid"
+
+- name: Information
+  debug:
+    msg: "Latest Besu version is {{ _besu_version }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,6 +13,16 @@
             ( besu_privacy_public_key_file != "" ) and
             ( besu_sync_mode == "FAST" )
 
+# Using internal variable _besu_version which allows override using set_fact
+- name: Set fact for Besu version
+  ansible.builtin.set_fact:
+    _besu_version: "{{ besu_version }}"
+
+# Retrive latest version when besu_version == 'latest'
+- name: Include task to retrieve latest version
+  ansible.builtin.include_tasks: "latest.yml"
+  when: besu_version == 'latest'
+
 - name: Include OS and distribution specific variables
   include_vars: "{{ item }}"
   with_first_found:


### PR DESCRIPTION
Ansible role supports setting `besu_version=='latest'` and role discover the latest released version from the GitHub repository. Since the besu_version may be set via command line, this variable cannot be updated using the set_fact. Introduced a new variable _besu_version which is updated to either value of besu_version or latest version discovered