### PR TITLE
skip compileSolidity

### DIFF
--- a/tasks/compile.yml
+++ b/tasks/compile.yml
@@ -25,7 +25,7 @@
     depth: 1
 
 - name: Build Besu
-  ansible.builtin.command: ./gradlew --no-daemon --parallel clean assemble
+  ansible.builtin.command: ./gradlew --no-daemon --parallel clean assemble -x compileSolidity
   args:
     chdir: /tmp/besu
   changed_when: true


### PR DESCRIPTION
There is no ARM release for solc and it's only needed for ATs so doesn't matter for the Build Besu task