### PR TITLE
Support gas free networks

### DIFF
--- a/templates/config.toml.j2
+++ b/templates/config.toml.j2
@@ -127,7 +127,10 @@ tx-pool-limit-by-account-percentage={{ besu_tx_pool_limit_by_account_percentage 
 tx-pool-max-size={{ besu_tx_pool_max_size }}
 tx-pool-retention-hours={{ besu_tx_pool_retention_hours }}
 {% endif %}
+# Only include tx-pool-price-bump if gas is not free (i.e., min_gas > 0).
+{% if besu_min_gas | int > 0 or besu_min_gas | lower != '0' %}
 tx-pool-price-bump={{ besu_tx_pool_price_bump }}
+{% endif %}
 
 # metrics
 metrics-enabled=true


### PR DESCRIPTION
When working with zero-base fee chains, Besu doesn't allow any `--tx-pool-price-bump` value other than `unset`. This pr includes the config parameter only if besu_min_gas is more than zero. 

For reference, this is the error if you start Besu with `besu_min_gas: 0`:

```bash
Failed to start Besu
picocli.CommandLine$ParameterException: Price bump option is not compatible with zero base fee market [--tx-pool-price-bump]
        at org.hyperledger.besu.cli.util.CommandLineUtils.failIfOptionDoesntMeetRequirement(CommandLineUtils.java:134)
        at org.hyperledger.besu.cli.options.TransactionPoolOptions.validate(TransactionPoolOptions.java:362)
        at org.hyperledger.besu.cli.BesuCommand.validateTransactionPoolOptions(BesuCommand.java:1479)
        at org.hyperledger.besu.cli.BesuCommand.validateOptions(BesuCommand.java:1446)
        at org.hyperledger.besu.cli.BesuCommand.run(BesuCommand.java:965)
        at picocli.CommandLine.executeUserObject(CommandLine.java:2030)
        at picocli.CommandLine.access$1500(CommandLine.java:148)
        at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2465)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2457)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2419)
        at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2277)
        at picocli.CommandLine$RunLast.execute(CommandLine.java:2421)
        at picocli.CommandLine.execute(CommandLine.java:2174)
        at org.hyperledger.besu.cli.BesuCommand.lambda$createExecuteTask$0(BesuCommand.java:893)
        at picocli.CommandLine.execute(CommandLine.java:2174)
        at org.hyperledger.besu.cli.BesuCommand.lambda$createPluginRegistrationTask$1(BesuCommand.java:902)
        at picocli.CommandLine.execute(CommandLine.java:2174)
        at org.hyperledger.besu.cli.util.ConfigDefaultValueProviderStrategy.execute(ConfigDefaultValueProviderStrategy.java:58)
        at picocli.CommandLine.execute(CommandLine.java:2174)
        at org.hyperledger.besu.cli.BesuCommand.executeCommandLine(BesuCommand.java:929)
        at org.hyperledger.besu.cli.BesuCommand.parse(BesuCommand.java:872)
        at org.hyperledger.besu.Besu.main(Besu.java:43)
Price bump option is not compatible with zero base fee market [--tx-pool-price-bump]
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Conditionally render `tx-pool-price-bump` only when `besu_min_gas` > 0 to support zero-base-fee networks.
> 
> - **Config template (`templates/config.toml.j2`)**:
>   - **Tx pool**: Conditionally include `tx-pool-price-bump` only when `besu_min_gas` > `0` (adds guard and comment) to avoid incompatibility on zero-base-fee networks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef92f9471bdfa31b94beaeee1203a041e685edc5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->